### PR TITLE
Add HasCallStack to executor APIs

### DIFF
--- a/c-apis/MXNet/Base/Executor.hs
+++ b/c-apis/MXNet/Base/Executor.hs
@@ -31,7 +31,12 @@ execBackward :: HasCallStack => Executor a -> [NDArray a] -> IO ()
 execBackward (Executor hdl) arrs = I.mxExecutorBackward hdl (map unNDArray arrs)
 
 execReshapeEx :: HasCallStack
-              => Executor a -> Bool -> Bool -> Context -> [(Text, NonEmpty Int)] -> IO ([NDArray a], [Maybe (NDArray a)], [NDArray a], Executor a)
+              => Executor a
+              -> Bool
+              -> Bool
+              -> Context
+              -> [(Text, NonEmpty Int)]
+              -> IO ([NDArray a], [Maybe (NDArray a)], [NDArray a], Executor a)
 execReshapeEx (Executor hdl) partial_shaping allow_up_sizing Context{..} input_shapes = do
     let (names, shapes) = unzip input_shapes
         arg_ind = scanl (+) 0 $ map length shapes

--- a/c-apis/MXNet/Base/Executor.hs
+++ b/c-apis/MXNet/Base/Executor.hs
@@ -19,18 +19,19 @@ instance ForeignData (Executor a) where
 
 instance NFData (Executor a)
 
-execGetOutputs :: Executor a -> IO [NDArray a]
+execGetOutputs :: HasCallStack => Executor a -> IO [NDArray a]
 execGetOutputs (Executor hdl) = do
     arrhdls <- I.mxExecutorOutputs hdl
     return $!! map NDArray arrhdls
 
-execForward :: Executor a -> Bool -> IO ()
+execForward :: HasCallStack => Executor a -> Bool -> IO ()
 execForward (Executor hdl) = I.mxExecutorForward hdl
 
-execBackward :: Executor a -> [NDArray a] -> IO ()
+execBackward :: HasCallStack => Executor a -> [NDArray a] -> IO ()
 execBackward (Executor hdl) arrs = I.mxExecutorBackward hdl (map unNDArray arrs)
 
-execReshapeEx :: Executor a -> Bool -> Bool -> Context -> [(Text, NonEmpty Int)] -> IO ([NDArray a], [Maybe (NDArray a)], [NDArray a], Executor a)
+execReshapeEx :: HasCallStack
+              => Executor a -> Bool -> Bool -> Context -> [(Text, NonEmpty Int)] -> IO ([NDArray a], [Maybe (NDArray a)], [NDArray a], Executor a)
 execReshapeEx (Executor hdl) partial_shaping allow_up_sizing Context{..} input_shapes = do
     let (names, shapes) = unzip input_shapes
         arg_ind = scanl (+) 0 $ map length shapes
@@ -47,10 +48,11 @@ execReshapeEx (Executor hdl) partial_shaping allow_up_sizing Context{..} input_s
         new_exec      = Executor new_hdl
     return $!! (new_arg_in', new_arg_grad', new_arg_aux', new_exec)
 
-execBind :: I.SymbolHandle -> Context -> [NDArray a] -> [Maybe (NDArray a, Int)] -> [NDArray a] ->  IO (Executor a)
+execBind :: HasCallStack
+         => I.SymbolHandle -> Context -> [NDArray a] -> [Maybe (NDArray a, Int)] -> [NDArray a] ->  IO (Executor a)
 execBind symbol Context{..} arg_in arg_gr_with_req arg_aux = do
     let (arg_gr, arg_gr_req) = unzip $ flip map arg_gr_with_req $ \case
-                                 Nothing -> (Nothing, 0)
+                                 Nothing         -> (Nothing, 0)
                                  Just (arr, req) -> (Just $ unNDArray arr, req)
     hdl <- I.mxExecutorBind symbol
                             _device_type _device_id
@@ -60,5 +62,5 @@ execBind symbol Context{..} arg_in arg_gr_with_req arg_aux = do
                             (map unNDArray arg_aux)
     return $ Executor hdl
 
-execFree :: Executor a -> IO ()
+execFree :: HasCallStack => Executor a -> IO ()
 execFree (Executor hdl) = I.withExecutorHandle hdl I.mxExecutorFree

--- a/c-apis/MXNet/Base/Raw/Executor.chs
+++ b/c-apis/MXNet/Base/Raw/Executor.chs
@@ -42,7 +42,8 @@ newExecutorHandle ptr = newForeignPtr_ ptr >>= return . ExecutorHandle
 peekExecutorHandle :: Ptr ExecutorHandlePtr -> IO ExecutorHandle
 peekExecutorHandle = peek >=> newExecutorHandle
 
-withExecutorHandleArray :: [ExecutorHandle] -> (Ptr ExecutorHandlePtr -> IO r) -> IO r
+withExecutorHandleArray :: HasCallStack
+                        => [ExecutorHandle] -> (Ptr ExecutorHandlePtr -> IO r) -> IO r
 withExecutorHandleArray array io = do
     let unExecutorHandle (ExecutorHandle fptr) = fptr
     r <- withArray (map (unsafeForeignPtrToPtr . unExecutorHandle) array) io
@@ -56,7 +57,7 @@ fun MXExecutorFree as mxExecutorFree_
     } -> `CInt'
 #}
 
-mxExecutorFree :: ExecutorHandlePtr -> IO ()
+mxExecutorFree :: HasCallStack => ExecutorHandlePtr -> IO ()
 mxExecutorFree = checked . mxExecutorFree_
 
 {#
@@ -67,7 +68,7 @@ fun MXExecutorPrint as mxExecutorPrint_
     } -> `CInt'
 #}
 
-mxExecutorPrint :: ExecutorHandle -> IO Text
+mxExecutorPrint :: HasCallStack => ExecutorHandle -> IO Text
 mxExecutorPrint = fmap unWrapText . checked . fmap (second WrapText) . mxExecutorPrint_
 
 {#
@@ -78,7 +79,7 @@ fun MXExecutorForward as mxExecutorForward_
     } -> `CInt'
 #}
 
-mxExecutorForward :: ExecutorHandle -> Bool -> IO ()
+mxExecutorForward :: HasCallStack => ExecutorHandle -> Bool -> IO ()
 mxExecutorForward exec train = checked $ mxExecutorForward_ exec is_train
   where
     is_train = if train then 1 else 0
@@ -103,7 +104,7 @@ fun MXExecutorBackward as mxExecutorBackward_
 #}
 #endif
 
-mxExecutorBackward :: ExecutorHandle -> [NDArrayHandle] -> IO ()
+mxExecutorBackward :: HasCallStack => ExecutorHandle -> [NDArrayHandle] -> IO ()
 mxExecutorBackward exec head_grads = checked $ mxExecutorBackward_ exec cnt head_grads
   where
     cnt = fromIntegral $ length head_grads
@@ -130,7 +131,7 @@ fun MXExecutorBackwardEx as mxExecutorBackwardEx_
 #}
 #endif
 
-mxExecutorBackwardEx :: ExecutorHandle -> [NDArrayHandle] -> Bool -> IO ()
+mxExecutorBackwardEx :: HasCallStack => ExecutorHandle -> [NDArrayHandle] -> Bool -> IO ()
 mxExecutorBackwardEx exec head_grads train = checked $ mxExecutorBackwardEx_ exec cnt head_grads is_train
   where
     cnt = fromIntegral $ length head_grads
@@ -145,7 +146,7 @@ fun MXExecutorOutputs as mxExecutorOutputs_
     } -> `CInt'
 #}
 
-mxExecutorOutputs :: ExecutorHandle -> IO [NDArrayHandle]
+mxExecutorOutputs :: HasCallStack => ExecutorHandle -> IO [NDArrayHandle]
 mxExecutorOutputs handle = do
     (cnt, ptr) <- checked $ mxExecutorOutputs_ handle
     handle_ptrs <- peekArray (fromIntegral cnt) ptr
@@ -187,7 +188,8 @@ fun MXExecutorBind as mxExecutorBind_
 
 makeNullNDArrayHandle = NDArrayHandle <$> newForeignPtr_ C2HSImp.nullPtr
 
-mxExecutorBind :: SymbolHandle
+mxExecutorBind :: HasCallStack
+               => SymbolHandle
                -> Int
                -> Int
                -> [NDArrayHandle]
@@ -248,7 +250,8 @@ fun MXExecutorBindX as mxExecutorBindX_
 #}
 #endif
 
-mxExecutorBindX :: SymbolHandle
+mxExecutorBindX :: HasCallStack
+                => SymbolHandle
                 -> Int
                 -> Int
                 -> [Text]
@@ -317,7 +320,8 @@ fun MXExecutorBindEX as mxExecutorBindEX_
 #}
 #endif
 
-mxExecutorBindEX :: SymbolHandle
+mxExecutorBindEX :: HasCallStack
+                 => SymbolHandle
                  -> Int
                  -> Int
                  -> [Text]
@@ -425,7 +429,8 @@ fun MXExecutorSimpleBind as mxExecutorSimpleBind_
 #}
 #endif
 
-mxExecutorSimpleBind :: SymbolHandle
+mxExecutorSimpleBind :: HasCallStack
+                     => SymbolHandle
                      -> Int -> Int                        -- device
                      -> [Text] -> [Int] -> [Int]        -- g2c
                      -> [Text] -> [Text]              -- provided_grad_req_list
@@ -561,7 +566,8 @@ fun MXExecutorReshapeEx as mxExecutorReshapeEx_
 #}
 #endif
 
-mxExecutorReshapeEx :: Bool -> Bool -> Int -> Int
+mxExecutorReshapeEx :: HasCallStack
+                    => Bool -> Bool -> Int -> Int
                     -> [Text] -> [Int] -> [Int]        -- group2ctx
                     -> [Text] -> [Int] -> [Int]        -- provided_arg_shapes
                     -> ExecutorHandle                    -- shared exec


### PR DESCRIPTION
Add HasCallStack to all the executor APIs. We can see a nice traceback when calling fitX() fails.