### PR TITLE
Support profiler

### DIFF
--- a/c-apis/MXNet/Base/Profiler.hs
+++ b/c-apis/MXNet/Base/Profiler.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds #-}
+module MXNet.Base.Profiler (
+    module MXNet.Base.Raw.Profiler,
+    setConfig,
+    withProfiler,
+    StatsFormat(..),
+    StatsOrder(..),
+    StatsSortBy(..),
+    stats,
+) where
+
+import           RIO
+
+import           MXNet.Base.Raw.Profiler
+import           MXNet.Base.Spec.Operator
+
+
+type instance ParameterList "profiler_config" t = [
+  '("filename", AttrReq String),
+  '("gpu_memory_profile_filename_prefix", AttrOpt String),
+  '("profile_all", AttrReq Bool),
+  '("profile_symbolic", AttrOpt Bool),
+  '("profile_imperative", AttrOpt Bool),
+  '("profile_memory", AttrOpt Bool),
+  '("profile_api", AttrOpt Bool),
+  '("continuous_dump", AttrOpt Bool),
+  '("dump_period", AttrOpt Float),
+  '("aggregate_stats", AttrOpt Bool)
+  ]
+
+setConfig :: (HasCallStack, Fullfilled "profiler_config" t args, Dump (ArgsHMap "profiler_config" t args))
+          => ArgsHMap "profiler_config" t args -> IO ()
+setConfig args = do
+    let kwargs = dump args
+    mxSetProfilerConfig kwargs
+
+withProfiler = bracket_ (mxSetProfilerState 1) (mxSetProfilerState 0)
+
+data StatsFormat = Table | Json
+  deriving Enum
+data StatsSortBy = Total | Average | Min | Max | Count
+  deriving Enum
+data StatsOrder = Ascending | Descending
+  deriving Enum
+
+stats :: HasCallStack => Bool -> StatsFormat -> StatsSortBy -> StatsOrder -> IO Text
+stats reset format sort_by order =
+    mxAggregateProfileStatsPrintEx
+        (fromEnum reset)
+        (fromEnum format)
+        (fromEnum sort_by)
+        (fromEnum order)
+

--- a/c-apis/MXNet/Base/Profiler.hs
+++ b/c-apis/MXNet/Base/Profiler.hs
@@ -34,7 +34,14 @@ setConfig args = do
     let kwargs = dump args
     mxSetProfilerConfig kwargs
 
+withProfiler :: IO a -> IO a
 withProfiler = bracket_ (mxSetProfilerState 1) (mxSetProfilerState 0)
+
+beginProfiler :: IO ()
+beginProfiler = mxSetProfilerState 1
+
+endProfiler :: IO ()
+endProfiler = mxSetProfilerState 0
 
 data StatsFormat = Table | Json
   deriving Enum

--- a/c-apis/MXNet/Base/Raw/Profiler.chs
+++ b/c-apis/MXNet/Base/Raw/Profiler.chs
@@ -1,0 +1,99 @@
+module MXNet.Base.Raw.Profiler where
+
+import RIO
+import RIO.List (unzip)
+import Foreign.Marshal (alloca)
+import Foreign.C.Types (CInt)
+import Foreign.C.String (CString)
+import Foreign.Storable (Storable(..))
+
+{# import MXNet.Base.Raw.Common #}
+
+#include <mxnet/c_api.h>
+
+{# typedef size_t CSize#}
+{# default in `CSize' [size_t] fromIntegral #}
+{# typedef mx_uint MX_UINT#}
+{# default in `MX_UINT' [mx_uint] id #}
+
+{#
+fun MXSetProfilerConfig as mxSetProfilerConfig_
+    {
+        `CInt',
+        withCStringArrayT* `[Text]',
+        withCStringArrayT* `[Text]'
+    } -> `CInt'
+#}
+
+mxSetProfilerConfig :: HasCallStack => [(Text, Text)] -> IO ()
+mxSetProfilerConfig kwargs = do
+    let num = fromIntegral $ length kwargs
+        (keys, vals) = unzip kwargs
+    checked $ mxSetProfilerConfig_ num keys vals
+
+{#
+fun MXSetProfilerState as mxSetProfilerState_
+    {
+        `CInt'
+    } -> `CInt'
+#}
+
+mxSetProfilerState :: HasCallStack => Int -> IO ()
+mxSetProfilerState = checked . mxSetProfilerState_ . fromIntegral
+
+{#
+fun MXDumpProfile as mxDumpProfile_
+    {
+        `CInt'
+    } -> `CInt'
+#}
+
+mxDumpProfile :: HasCallStack => Int -> IO ()
+mxDumpProfile = checked . mxDumpProfile_ . fromIntegral
+
+{#
+fun MXAggregateProfileStatsPrint as mxAggregateProfileStatsPrint_
+    {
+        alloca- `Text' peekCStringPtrT*,
+        `CInt'
+    } -> `CInt'
+#}
+
+mxAggregateProfileStatsPrint :: HasCallStack => Int -> IO Text
+mxAggregateProfileStatsPrint = fmap unWrapText
+                                    . checked
+                                    . fmap (second WrapText)
+                                    . mxAggregateProfileStatsPrint_
+                                    . fromIntegral
+
+{#
+fun MXAggregateProfileStatsPrintEx as mxAggregateProfileStatsPrintEx_
+    {
+        alloca- `C2HSImp.Ptr CString' id,
+        `CInt',
+        `CInt',
+        `CInt',
+        `CInt'
+    } -> `CInt'
+#}
+
+mxAggregateProfileStatsPrintEx :: HasCallStack => Int -> Int -> Int -> Int -> IO Text
+mxAggregateProfileStatsPrintEx reset format sort_by ascending = do
+    let reset'     = fromIntegral reset
+        format'    = fromIntegral format
+        sort_by'   = fromIntegral sort_by
+        ascending' = fromIntegral ascending
+    (rc, pcstr) <- mxAggregateProfileStatsPrintEx_ reset' format' sort_by' ascending'
+    checkRC rc
+    cstr <- peek pcstr
+    peekCStringT cstr
+
+{#
+fun MXProfilePause as mxProfilePause_
+    {
+        `CInt'
+    } -> `CInt'
+#}
+
+mxProfilePause :: HasCallStack => Int -> IO ()
+mxProfilePause = checked . mxProfilePause_ . fromIntegral

--- a/fei-base.cabal
+++ b/fei-base.cabal
@@ -88,12 +88,14 @@ library
                        MXNet.Base.Spec.Operator,
                        MXNet.Base.Spec.HMap
                        MXNet.Base.Operators.Tensor,
-                       MXNet.Base.DataIter
+                       MXNet.Base.DataIter,
+                       MXNet.Base.Profiler
   other-modules:       MXNet.Base.Raw.Common,
                        MXNet.Base.Raw.NDArray,
                        MXNet.Base.Raw.Symbol,
                        MXNet.Base.Raw.Executor,
                        MXNet.Base.Raw.DataIter,
+                       MXNet.Base.Raw.Profiler,
                        MXNet.Base.Tensor.Class,
                        MXNet.Base.Tensor.Functional
   extra-libraries:     mxnet


### PR DESCRIPTION
This PR adds APIs for profiling.

- Call `setConfig` before all profiling sections
- `beginProfiler` to start gathering statics
- `endProfiler` to stop
- `stats`: format the aggregated statistics (only available if `aggregate_stats` is set to True)