### PR TITLE
Resolve the race condition between profiling and free

### DIFF
--- a/c-apis/MXNet/Base/Profiler.hs
+++ b/c-apis/MXNet/Base/Profiler.hs
@@ -11,6 +11,7 @@ module MXNet.Base.Profiler (
 
 import           RIO
 
+import           MXNet.Base.Raw.Common    (flagSafeToFree)
 import           MXNet.Base.Raw.Profiler
 import           MXNet.Base.Spec.Operator
 
@@ -35,7 +36,7 @@ setConfig args = do
     mxSetProfilerConfig kwargs
 
 withProfiler :: IO a -> IO a
-withProfiler = bracket_ (mxSetProfilerState 1) (mxSetProfilerState 0)
+withProfiler = bracket_ (withMVar flagSafeToFree $ \_ -> mxSetProfilerState 1) (mxSetProfilerState 0)
 
 beginProfiler :: IO ()
 beginProfiler = mxSetProfilerState 1

--- a/c-apis/MXNet/Base/Raw/NDArray.chs
+++ b/c-apis/MXNet/Base/Raw/NDArray.chs
@@ -41,7 +41,7 @@ touchNDArrayHandle (NDArrayHandle fptr) = touchForeignPtr fptr
 
 newNDArrayHandle :: NDArrayHandlePtr -> IO NDArrayHandle
 newNDArrayHandle ptr = do
-    hdl <- newForeignPtr ptr (mxNDArrayFree ptr)
+    hdl <- newForeignPtr ptr (safeFreeWith mxNDArrayFree ptr)
     return $ NDArrayHandle hdl
 
 peekNDArrayHandle :: Ptr NDArrayHandlePtr -> IO NDArrayHandle

--- a/c-apis/MXNet/Base/Raw/Symbol.chs
+++ b/c-apis/MXNet/Base/Raw/Symbol.chs
@@ -39,7 +39,7 @@ touchSymbolHandle :: SymbolHandle -> IO ()
 touchSymbolHandle (SymbolHandle fptr) = touchForeignPtr fptr
 
 newSymbolHandle :: SymbolHandlePtr -> IO SymbolHandle
-newSymbolHandle ptr = newForeignPtr ptr (mxSymbolFree ptr) >>= return . SymbolHandle
+newSymbolHandle ptr = newForeignPtr ptr (safeFreeWith mxSymbolFree ptr) >>= return . SymbolHandle
 
 peekSymbolHandle :: Ptr SymbolHandlePtr -> IO SymbolHandle
 peekSymbolHandle = peek >=> newSymbolHandle


### PR DESCRIPTION
Free of ndarray and symbol happens concurrently in a separate thread. It may happen that you turn on the profiling in the middle of a free action, then an exception will occur and says `terminate called after throwing an instance of 'dmlc::Error'  what():  [09:54:38] ../src/c_api/c_api_profile.cc:141: Check failed: !thread_profiling_data.calls_.empty():`. This is triggered because the call to the free API starts with profiling disabled but ends with enabled.